### PR TITLE
Add automated deploy workflow for main branch

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -1,0 +1,31 @@
+name: Auto Deploy to Main Host
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      TARGET_DIR: ${{ secrets.MAIN_HOST_TARGET_DIR }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Sync project files to host server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.MAIN_HOST }}
+          username: ${{ secrets.MAIN_HOST_USER }}
+          key: ${{ secrets.MAIN_HOST_SSH_KEY }}
+          port: ${{ secrets.MAIN_HOST_PORT }}
+          source: "."
+          target: ${{ env.TARGET_DIR != '' && env.TARGET_DIR || '/var/www/html' }}
+          strip_components: 0
+          overwrite: true
+          rm: true
+          include_hidden: true
+          debug: true


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that automatically syncs the repository to the main host on each push to `main`
- ensure the deploy step overwrites existing files and removes files not present locally

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d9ef8f9ef883338231c8942159d03c