### PR TITLE
Improve API security and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Edit the partial that matches the template you are working on; `assets/css/style
 The front-end no longer stores customer accounts in `localStorage`. A lightweight PHP API in `public_html/api/` persists customers to MySQL using the schema in `database/init.sql`. Passwords are hashed with bcrypt and never sent back to the browser.
 
 1. Install dependencies with `composer install` inside `public_html/api/` (a `vendor/` directory is bundled for shared hosts without Composer access).
-2. Copy `.env.sample` to `.env` within `public_html/api/` and update it with your Hostinger database credentials plus any role codes.
+2. Copy `.env.sample` to `.env` within `public_html/api/` and update it with your Hostinger database credentials plus any role codes. Avoid placing raw passwords in version control—set `DB_PASSWORD_ENV` to the name of the environment variable that stores your database password (the API automatically checks common defaults, including the server-managed secret exposed during deployment).
 3. Deploy the contents of `public_html/api/` to your hosting account; point requests for `/api/*` to `public_html/api/public/index.php` (the included `.htaccess` handles URL rewriting). The front-end will call `/api/auth/*` endpoints.
 
 ## Local development tips

--- a/public_html/api/src/Database.php
+++ b/public_html/api/src/Database.php
@@ -6,6 +6,7 @@ namespace App;
 
 use PDO;
 use PDOException;
+use RuntimeException;
 
 class Database
 {
@@ -31,6 +32,10 @@ class Database
             $settings['name']
         );
 
+        if ($settings['password'] === '') {
+            throw new RuntimeException('Database credentials are not configured.');
+        }
+
         try {
             $pdo = new PDO(
                 $dsn,
@@ -43,7 +48,8 @@ class Database
                 ]
             );
         } catch (PDOException $exception) {
-            throw new PDOException('Failed to connect to the database: ' . $exception->getMessage(), (int) $exception->getCode(), $exception);
+            error_log('Database connection failed: ' . $exception->getMessage());
+            throw new RuntimeException('Failed to connect to the database.', (int) $exception->getCode(), $exception);
         }
 
         $this->connection = $pdo;


### PR DESCRIPTION
## Summary
- load the database password from server-managed environment secrets instead of hard-coded values
- harden the database connection bootstrap and API entry point with additional validation and graceful failures
- add defensive error handling throughout the authentication service and document how to configure password secrets

## Testing
- php -l public_html/api/src/Config.php
- php -l public_html/api/src/Database.php
- php -l public_html/api/src/Services/AuthService.php
- php -l public_html/api/public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d9f6bad1cc833396f39df84ed74cc2