### PR TITLE
Ensure deployments retain env.local.js

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -9,11 +9,25 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      TARGET_DIR: ${{ secrets.MAIN_HOST_TARGET_DIR }}
+      TARGET_DIR: ${{ secrets.MAIN_HOST_TARGET_DIR != '' && secrets.MAIN_HOST_TARGET_DIR || '/var/www/html' }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Clean target directory except env.local.js
+        uses: appleboy/ssh-action@v1.0.0
+        env:
+          TARGET_DIR: ${{ env.TARGET_DIR }}
+        with:
+          host: ${{ secrets.MAIN_HOST }}
+          username: ${{ secrets.MAIN_HOST_USER }}
+          key: ${{ secrets.MAIN_HOST_SSH_KEY }}
+          port: ${{ secrets.MAIN_HOST_PORT }}
+          script: |
+            TARGET_DIR="${TARGET_DIR:-/var/www/html}"
+            mkdir -p "$TARGET_DIR"
+            find "$TARGET_DIR" -mindepth 1 -maxdepth 1 ! -name 'env.local.js' -exec rm -rf {} +
 
       - name: Sync project files to host server
         uses: appleboy/scp-action@v0.1.7
@@ -23,7 +37,7 @@ jobs:
           key: ${{ secrets.MAIN_HOST_SSH_KEY }}
           port: ${{ secrets.MAIN_HOST_PORT }}
           source: "."
-          target: ${{ env.TARGET_DIR != '' && env.TARGET_DIR || '/var/www/html' }}
+          target: ${{ env.TARGET_DIR }}
           strip_components: 0
           overwrite: true
           rm: true

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -16,6 +16,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Clean target directory except env.local.js
+        uses: appleboy/ssh-action@v1.0.0
+        env:
+          TARGET_DIR: ${{ github.event.inputs.target_directory }}
+        with:
+          host: ${{ secrets.MAIN_HOST }}
+          username: ${{ secrets.MAIN_HOST_USER }}
+          key: ${{ secrets.MAIN_HOST_SSH_KEY }}
+          port: ${{ secrets.MAIN_HOST_PORT }}
+          script: |
+            TARGET_DIR="${TARGET_DIR:-/var/www/html}"
+            mkdir -p "$TARGET_DIR"
+            find "$TARGET_DIR" -mindepth 1 -maxdepth 1 ! -name 'env.local.js' -exec rm -rf {} +
+
       - name: Sync project files to host server
         uses: appleboy/scp-action@v0.1.7
         with:


### PR DESCRIPTION
## Summary
- clean the remote deployment directory via SSH while preserving env.local.js
- reuse the computed target directory for automatic and manual deployments before syncing files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9f8e5b030833398210af845302210