### PR TITLE
Handle read-only files during deploy cleanup

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -27,7 +27,9 @@ jobs:
           script: |
             TARGET_DIR="${TARGET_DIR:-/var/www/html}"
             mkdir -p "$TARGET_DIR"
-            find "$TARGET_DIR" -mindepth 1 -maxdepth 1 ! -name 'env.local.js' -exec rm -rf {} +
+            if ! find "$TARGET_DIR" -mindepth 1 -maxdepth 1 ! -name 'env.local.js' -exec rm -rf {} + 2>/dev/null; then
+              echo "Warning: Some files could not be removed from $TARGET_DIR (possibly read-only)."
+            fi
 
       - name: Sync project files to host server
         uses: appleboy/scp-action@v0.1.7


### PR DESCRIPTION
## Summary
- prevent the deployment cleanup step from failing when the target directory contains read-only files by tolerating removal errors
- log a warning when files cannot be removed so operators are aware

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9fbbaa65083339f7f9f1c5f22c02f