### PR TITLE
Limit auth features to ecommerce mode

### DIFF
--- a/assets/js/core/forms.js
+++ b/assets/js/core/forms.js
@@ -8,7 +8,8 @@ import {
 export function bindContact(formId, statusId, configKey = "contact") {
   const form = byId(formId);
   const status = byId(statusId);
-  const config = window.DATA?.forms?.[configKey] || {};
+  const resolvedKey = form?.dataset?.formKey || configKey;
+  const config = window.DATA?.forms?.[resolvedKey] || window.DATA?.forms?.[configKey] || {};
   if (!form) return;
 
   form.addEventListener("submit", async (event) => {

--- a/assets/js/data/pages/contact.js
+++ b/assets/js/data/pages/contact.js
@@ -4,4 +4,6 @@ export const contactPage = {
   meta: seoContent.contact,
   intro:
     "Give us the essentials and we'll return a tailored proposal with security guidance and delivery milestones.",
+  basicNotice:
+    "Package and service selection is available when the e-commerce experience is enabled. Use the form below to send us a quick message and we'll follow up personally.",
 };

--- a/assets/js/data/pages/home.js
+++ b/assets/js/data/pages/home.js
@@ -186,10 +186,16 @@ export const homePage = {
   },
   contact: {
     heading: "Ready to scope your project?",
+    basicHeading: "Tell us about your project",
     points: [
       "Get a tailored roadmap and investment range in 48 hours",
       "Security and performance baked into every sprint",
       "Flexible retainers for iterative product delivery",
+    ],
+    basicPoints: [
+      "Share your goals and we'll organise a discovery call",
+      "Security guidance without the full commerce experience",
+      "Personal replies from the founders within one business day",
     ],
   },
 };

--- a/assets/js/data/site/contact.js
+++ b/assets/js/data/site/contact.js
@@ -1,7 +1,10 @@
 export const contact = {
   heading: "Let's build your next secure product",
+  basicHeading: "Let's talk about your goals",
   copy:
     "Tell us where your roadmap sits—new launch, MVP, or platform refresh. Pasan replies personally with next steps within one business day.",
+  basicCopy:
+    "Share a short note about your project and we'll get in touch to plan the right next step.",
   emailLabel: "ionfo@yberion.com",
   phoneLabel: "+61 434 438 494",
   locationLabel: "Melbourne, Australia",

--- a/assets/js/data/site/forms.js
+++ b/assets/js/data/site/forms.js
@@ -6,6 +6,14 @@ export const forms = {
     success: "Thanks for reaching out! We'll reply within one business day.",
     error: "We couldn't send your message. Please email rans.rath@gmail.com instead.",
   },
+  basicContact: {
+    endpointKey: "contactEndpoint",
+    defaultEndpoint: "https://formsubmit.co/ajax/rans.rath@gmail.com",
+    subject: "Zyvrix — Basic site enquiry",
+    success: "Thanks for saying hello. We'll reply with next steps soon.",
+    error:
+      "We couldn't deliver your message. Please email rans.rath@gmail.com and we'll get back to you.",
+  },
   quote: {
     endpointKey: "quoteEndpoint",
     defaultEndpoint: "https://formsubmit.co/ajax/rans.rath@gmail.com",

--- a/assets/js/renderers/contact.js
+++ b/assets/js/renderers/contact.js
@@ -1,89 +1,145 @@
 import { byId, formatCurrency } from "../core/utils.js";
 import { populateContactDetails } from "./shared.js";
+import { isEcommerceEnabled } from "../core/siteMode.js";
 
 export function renderContactPage(data) {
+  const ecommerceEnabled = isEcommerceEnabled();
+  const pageConfig = data.pages?.contact || {};
   const intro = byId("contactIntro");
-  if (intro) intro.textContent = data.pages?.contact?.intro || "";
+  if (intro) {
+    intro.textContent = ecommerceEnabled
+      ? pageConfig.intro || ""
+      : data.contact?.basicCopy || pageConfig.intro || "";
+  }
 
   const metaHeading = byId("contactHeading");
-  if (metaHeading) metaHeading.textContent = data.contact?.heading || "";
+  if (metaHeading) {
+    metaHeading.textContent = ecommerceEnabled
+      ? data.contact?.heading || ""
+      : data.contact?.basicHeading || data.contact?.heading || "";
+  }
 
   populateContactDetails(data);
+
+  const form = byId("contactForm2");
+  if (form) {
+    form.dataset.formKey = ecommerceEnabled ? "contact" : "basicContact";
+    const hiddenField = form.querySelector("input[name='form']");
+    if (hiddenField) {
+      hiddenField.value = ecommerceEnabled ? "Contact page" : "Contact page (basic site)";
+    }
+  }
+
+  const notice = byId("contactModeNotice");
+  if (notice) {
+    if (!ecommerceEnabled) {
+      notice.hidden = false;
+      notice.textContent =
+        pageConfig.basicNotice ||
+        "Detailed package selection is available in the e-commerce experience. Share a quick note below and we'll follow up personally.";
+    } else {
+      notice.hidden = true;
+      notice.textContent = "";
+    }
+  }
 
   const packagesTarget = byId("contactPackages");
   if (packagesTarget) {
     packagesTarget.innerHTML = "";
-    const fallbackCurrency = data.billing?.currency || "AUD";
-    const packageOptions = (data.pricingGroups || []).flatMap((group) =>
-      (group.plans || []).map((plan) => ({
-        value: `${group.label} — ${plan.label}`,
-        label: `${group.label} — ${plan.label}`,
-        summary: plan.summary || "",
-        priceLabel: plan.price
-          ? formatCurrency(plan.price, plan.currency || fallbackCurrency)
-          : "Custom pricing",
-        hasPrice: Boolean(plan.price),
-      }))
-    );
-
-    if (packageOptions.length === 0) {
-      const empty = document.createElement("p");
-      empty.className = "muted";
-      empty.textContent =
-        "Package options are being finalised. Share your goals in the project background field.";
-      packagesTarget.appendChild(empty);
+    const fieldset = packagesTarget.closest("fieldset");
+    if (!ecommerceEnabled) {
+      if (fieldset) {
+        fieldset.hidden = true;
+      }
     } else {
-      packageOptions.forEach((pkg, index) => {
-        const option = document.createElement("label");
-        option.className = "service-option package-option";
+      if (fieldset) {
+        fieldset.hidden = false;
+      }
+      const fallbackCurrency = data.billing?.currency || "AUD";
+      const packageOptions = (data.pricingGroups || []).flatMap((group) =>
+        (group.plans || []).map((plan) => ({
+          value: `${group.label} — ${plan.label}`,
+          label: `${group.label} — ${plan.label}`,
+          summary: plan.summary || "",
+          priceLabel: plan.price
+            ? formatCurrency(plan.price, plan.currency || fallbackCurrency)
+            : "Custom pricing",
+          hasPrice: Boolean(plan.price),
+        }))
+      );
 
-        const input = document.createElement("input");
-        input.type = "radio";
-        input.name = "package";
-        input.value = pkg.value;
-        if (index === 0) input.required = true;
+      if (packageOptions.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "muted";
+        empty.textContent =
+          "Package options are being finalised. Share your goals in the project background field.";
+        packagesTarget.appendChild(empty);
+      } else {
+        packageOptions.forEach((pkg, index) => {
+          const option = document.createElement("label");
+          option.className = "service-option package-option";
 
-        const content = document.createElement("span");
+          const input = document.createElement("input");
+          input.type = "radio";
+          input.name = "package";
+          input.value = pkg.value;
+          if (index === 0) {
+            input.required = true;
+            input.dataset.required = "true";
+          }
 
-        const title = document.createElement("strong");
-        title.textContent = pkg.label;
-        content.appendChild(title);
+          const content = document.createElement("span");
 
-        if (pkg.priceLabel) {
-          const price = document.createElement("em");
-          price.textContent = pkg.hasPrice
-            ? `${pkg.priceLabel} + GST`
-            : pkg.priceLabel;
-          content.appendChild(price);
-        }
+          const title = document.createElement("strong");
+          title.textContent = pkg.label;
+          content.appendChild(title);
 
-        if (pkg.summary) {
-          const summary = document.createElement("p");
-          summary.textContent = pkg.summary;
-          content.appendChild(summary);
-        }
+          if (pkg.priceLabel) {
+            const price = document.createElement("em");
+            price.textContent = pkg.hasPrice
+              ? `${pkg.priceLabel} + GST`
+              : pkg.priceLabel;
+            content.appendChild(price);
+          }
 
-        option.append(input, content);
-        packagesTarget.appendChild(option);
-      });
+          if (pkg.summary) {
+            const summary = document.createElement("p");
+            summary.textContent = pkg.summary;
+            content.appendChild(summary);
+          }
+
+          option.append(input, content);
+          packagesTarget.appendChild(option);
+        });
+      }
     }
   }
 
   const servicesTarget = byId("contactServices");
   if (servicesTarget) {
     servicesTarget.innerHTML = "";
-    (data.serviceCatalog || []).forEach((service) => {
-      const item = document.createElement("label");
-      item.className = "service-option";
-      item.innerHTML = `
-        <input type="checkbox" name="services" value="${service.title}" />
-        <span>
-          <strong>${service.title}</strong>
-          <em>${service.priceLabel || "Tailored pricing"}</em>
-          <p>${service.description}</p>
-        </span>
-      `;
-      servicesTarget.appendChild(item);
-    });
+    const fieldset = servicesTarget.closest("fieldset");
+    if (!ecommerceEnabled) {
+      if (fieldset) {
+        fieldset.hidden = true;
+      }
+    } else {
+      if (fieldset) {
+        fieldset.hidden = false;
+      }
+      (data.serviceCatalog || []).forEach((service) => {
+        const item = document.createElement("label");
+        item.className = "service-option";
+        item.innerHTML = `
+          <input type="checkbox" name="services" value="${service.title}" />
+          <span>
+            <strong>${service.title}</strong>
+            <em>${service.priceLabel || "Tailored pricing"}</em>
+            <p>${service.description}</p>
+          </span>
+        `;
+        servicesTarget.appendChild(item);
+      });
+    }
   }
 }

--- a/assets/js/renderers/home.js
+++ b/assets/js/renderers/home.js
@@ -172,17 +172,37 @@ export function renderHomePage(data) {
   renderTeamSpotlight(page.spotlight, data.team, data.socials);
   renderFaqs(byId("faqsContainer"), data.faqs);
 
+  const contactConfig = page.contact || {};
   const contactHeading = byId("homeContactHeading");
-  if (contactHeading) contactHeading.textContent = page.contact?.heading || "";
+  if (contactHeading) {
+    contactHeading.textContent = ecommerceEnabled
+      ? contactConfig.heading || ""
+      : contactConfig.basicHeading || contactConfig.heading || "";
+  }
   const contactPoints = byId("homeContactPoints");
   if (contactPoints) {
     contactPoints.innerHTML = "";
-    (page.contact?.points || []).forEach((point) => {
+    const points = ecommerceEnabled
+      ? contactConfig.points || []
+      : contactConfig.basicPoints || contactConfig.points || [];
+    points.forEach((point) => {
       const li = document.createElement("li");
       li.textContent = point;
       contactPoints.appendChild(li);
     });
   }
   const contactCopy = byId("contactCopy");
-  if (contactCopy) contactCopy.textContent = data.contact?.copy || "";
+  if (contactCopy) {
+    contactCopy.textContent = ecommerceEnabled
+      ? data.contact?.copy || ""
+      : data.contact?.basicCopy || data.contact?.copy || "";
+  }
+  const homeForm = document.getElementById("contactForm");
+  if (homeForm) {
+    homeForm.dataset.formKey = ecommerceEnabled ? "contact" : "basicContact";
+    const hiddenField = homeForm.querySelector("input[name='form']");
+    if (hiddenField) {
+      hiddenField.value = ecommerceEnabled ? "Home contact" : "Home contact (basic site)";
+    }
+  }
 }

--- a/contact.html
+++ b/contact.html
@@ -141,6 +141,7 @@
                   />
                 </div>
               </div>
+              <div id="contactModeNotice" class="callout callout--info" hidden></div>
               <fieldset class="service-selector package-selector">
                 <legend>Select a starting package</legend>
                 <div id="contactPackages" class="service-selector__grid"></div>

--- a/login.html
+++ b/login.html
@@ -69,6 +69,7 @@
           continue checkout. Database connections stay on the server so secrets
           never appear in the browser.
         </p>
+        <div id="authModeNotice" class="callout callout--info" hidden></div>
         <div
           id="dbConfigNotice"
           class="auth-db"

--- a/signup.html
+++ b/signup.html
@@ -72,6 +72,7 @@
           and confirm projects with confidence. Passwords are hashed locally
           before being stored.
         </p>
+        <div id="authModeNotice" class="callout callout--info" hidden></div>
         <div class="auth-provider" aria-label="Social sign-up options">
           <div id="googleSignup" class="oauth-button-slot"></div>
           <p


### PR DESCRIPTION
## Summary
- gate the login and signup experiences behind the ecommerce site mode, including nav visibility and contextual notices when accounts are unavailable
- simplify the contact workflow in basic mode while keeping package/service selectors for ecommerce visitors, and align supporting data/configuration

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d9fb5d5ab88333b6bfabac50c8feda