### PR TITLE
Add workflow to lint PHP API

### DIFF
--- a/.github/workflows/app-tests.yml
+++ b/.github/workflows/app-tests.yml
@@ -1,0 +1,35 @@
+name: Application Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  php-lint:
+    name: Lint PHP API
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          coverage: none
+
+      - name: Validate Composer configuration
+        working-directory: public_html/api
+        run: composer validate
+
+      - name: Install Composer dependencies
+        working-directory: public_html/api
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Lint PHP source files
+        run: |
+          find public_html/api -path "public_html/api/vendor" -prune -o -name '*.php' -print0 \
+            | xargs -0 -n 1 php -l


### PR DESCRIPTION
## Summary
- add an automated workflow that runs on pushes and pull requests
- validate the Composer configuration for the PHP API and install dependencies
- lint the custom PHP source files to catch syntax issues early

## Testing
- composer validate --working-dir=public_html/api
- find public_html/api -path "public_html/api/vendor" -prune -o -name '*.php' -print0 | xargs -0 -n 1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68da04e18c588333bc152d34f5ea20e6