### PR TITLE
Remove basic contact notice and correct contact email

### DIFF
--- a/assets/js/data/pages/contact.js
+++ b/assets/js/data/pages/contact.js
@@ -4,6 +4,4 @@ export const contactPage = {
   meta: seoContent.contact,
   intro:
     "Give us the essentials and we'll return a tailored proposal with security guidance and delivery milestones.",
-  basicNotice:
-    "Package and service selection is available when the e-commerce experience is enabled. Use the form below to send us a quick message and we'll follow up personally.",
 };

--- a/assets/js/data/site/contact.js
+++ b/assets/js/data/site/contact.js
@@ -5,7 +5,7 @@ export const contact = {
     "Tell us where your roadmap sits—new launch, MVP, or platform refresh. Pasan replies personally with next steps within one business day.",
   basicCopy:
     "Share a short note about your project and we'll get in touch to plan the right next step.",
-  emailLabel: "ionfo@yberion.com",
+  emailLabel: "info@yberion.com",
   phoneLabel: "+61 434 438 494",
   locationLabel: "Melbourne, Australia",
   responseTime: "Replies within one business day",

--- a/assets/js/renderers/contact.js
+++ b/assets/js/renderers/contact.js
@@ -32,14 +32,18 @@ export function renderContactPage(data) {
 
   const notice = byId("contactModeNotice");
   if (notice) {
+    // Basic mode should not surface an additional notice—showing the message
+    // suggested switching to e-commerce, which was confusing for customers
+    // intentionally browsing the brochure experience. We now keep the element
+    // hidden in basic mode, and still reset it when the commerce flow is
+    // active.
     if (!ecommerceEnabled) {
-      notice.hidden = false;
-      notice.textContent =
-        pageConfig.basicNotice ||
-        "Detailed package selection is available in the e-commerce experience. Share a quick note below and we'll follow up personally.";
-    } else {
       notice.hidden = true;
       notice.textContent = "";
+    } else {
+      const noticeCopy = pageConfig.notice || "";
+      notice.hidden = !noticeCopy;
+      notice.textContent = noticeCopy;
     }
   }
 


### PR DESCRIPTION
## Summary
- hide the contact mode notice in basic mode while keeping support for optional ecommerce messaging
- remove the unused basic notice copy and fix the contact email label typo

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68da05a6c9a483339d89b9100287ec2e