### PR TITLE
Add API endpoint smoke tests and fix team card styles

### DIFF
--- a/.github/workflows/app-tests.yml
+++ b/.github/workflows/app-tests.yml
@@ -33,3 +33,64 @@ jobs:
         run: |
           find public_html/api -path "public_html/api/vendor" -prune -o -name '*.php' -print0 \
             | xargs -0 -n 1 php -l
+
+  api-endpoints:
+    name: API Endpoint Smoke Tests
+    runs-on: ubuntu-latest
+    needs: php-lint
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: zyvrix
+          MYSQL_USER: zyvrix
+          MYSQL_PASSWORD: zyvrix
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install MySQL client
+        run: sudo apt-get update && sudo apt-get install -y mysql-client
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          coverage: none
+
+      - name: Install Composer dependencies
+        working-directory: public_html/api
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Wait for database to be ready
+        run: |
+          for i in {1..30}; do
+            if mysqladmin ping -h 127.0.0.1 -P 3306 -uroot -proot --silent; then
+              echo "MySQL is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "MySQL did not start in time" >&2
+          exit 1
+
+      - name: Prepare schema
+        run: mysql -h 127.0.0.1 -P 3306 -u zyvrix -pzyvrix zyvrix < database/init.sql
+
+      - name: Run endpoint smoke tests
+        env:
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_NAME: zyvrix
+          DB_USER: zyvrix
+          DB_PASSWORD: zyvrix
+        run: bash public_html/api/tests/endpoint-smoke.sh

--- a/assets/css/components/about.css
+++ b/assets/css/components/about.css
@@ -239,6 +239,9 @@
 .spotlight-card .spotlight-socials .social {
   display: flex;
   gap: 10px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 .spotlight-card .spotlight-socials a {

--- a/public_html/api/tests/endpoint-smoke.sh
+++ b/public_html/api/tests/endpoint-smoke.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST="127.0.0.1"
+PORT="8080"
+BASE_URL="http://${HOST}:${PORT}"
+DOCROOT="public_html/api/public"
+ROUTER="${DOCROOT}/index.php"
+
+log() {
+  printf '\n[%s] %s\n' "$(date '+%H:%M:%S')" "$*"
+}
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMPDIR"
+}
+
+TMPDIR=$(mktemp -d)
+trap cleanup EXIT
+
+log "Starting PHP development server for API tests..."
+php -S "${HOST}:${PORT}" -t "$DOCROOT" "$ROUTER" >"$TMPDIR/server.log" 2>&1 &
+SERVER_PID=$!
+
+log "Waiting for server to be ready..."
+for _ in {1..20}; do
+  if curl -sS "${BASE_URL}/health" >/dev/null 2>&1; then
+    READY=1
+    break
+  fi
+  sleep 1
+  READY=0
+done
+
+if [[ "${READY:-0}" -ne 1 ]]; then
+  log "Server failed to start. Output:" >&2
+  cat "$TMPDIR/server.log" >&2
+  exit 1
+fi
+
+log "Server is ready; running endpoint checks."
+
+check_endpoint() {
+  local method="$1"
+  local path="$2"
+  local expected_status="$3"
+  local body="${4:-}"
+  local description="${5:-$method $path}"
+
+  local response_file="$TMPDIR/response.json"
+  local status
+
+  if [[ -n "$body" ]]; then
+    status=$(curl -sS -o "$response_file" -w '%{http_code}' \
+      -X "$method" \
+      -H 'Content-Type: application/json' \
+      -d "$body" \
+      "${BASE_URL}${path}")
+  else
+    status=$(curl -sS -o "$response_file" -w '%{http_code}' \
+      -X "$method" \
+      "${BASE_URL}${path}")
+  fi
+
+  if [[ "$status" != "$expected_status" ]]; then
+    log "${description} failed: expected status $expected_status, got $status" >&2
+    cat "$response_file" >&2
+    return 1
+  fi
+
+  if ! grep -q '"ok":true' "$response_file" && ! grep -q '"status":"ok"' "$response_file"; then
+    log "${description} failed: response did not indicate success" >&2
+    cat "$response_file" >&2
+    return 1
+  fi
+
+  log "${description} passed with status ${status}."
+}
+
+check_endpoint GET /health 200 '' 'Health check'
+
+EMAIL="test.$(date +%s).$RANDOM@example.com"
+PASSWORD="Sup3rSecure!"
+NAME="Workflow Smoke"
+
+check_endpoint POST /api/auth/signup 201 "{\"name\":\"$NAME\",\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}" "Signup endpoint"
+check_endpoint POST /api/auth/login 200 "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}" "Login endpoint"
+
+PROVIDER_EMAIL="provider.$(date +%s).$RANDOM@example.com"
+check_endpoint POST /api/auth/provider 200 "{\"email\":\"$PROVIDER_EMAIL\",\"name\":\"$NAME\",\"provider\":\"google\"}" "Provider endpoint"
+check_endpoint POST /api/auth/logout 200 '{}' "Logout endpoint"
+
+log "All endpoint checks passed."


### PR DESCRIPTION
## Summary
- remove the default list markers from team card social icon lists to eliminate the visible dots
- add a shell-based smoke test that sequentially exercises the API authentication endpoints
- extend the CI workflow to provision MySQL and run the smoke tests after linting

## Testing
- not run (MySQL service not available in the local container)


------
https://chatgpt.com/codex/tasks/task_e_68da083d54948333b348c897e8241cd2