### PR TITLE
Default to basic site mode

### DIFF
--- a/assets/js/core/siteMode.js
+++ b/assets/js/core/siteMode.js
@@ -9,7 +9,9 @@ let cachedMode;
 
 function normalizeMode(value) {
   const mode = String(value || "").toLowerCase();
-  return mode === SITE_MODES.BASIC ? SITE_MODES.BASIC : SITE_MODES.ECOMMERCE;
+  if (mode === SITE_MODES.ECOMMERCE) return SITE_MODES.ECOMMERCE;
+  if (mode === SITE_MODES.BASIC) return SITE_MODES.BASIC;
+  return SITE_MODES.BASIC;
 }
 
 function readStoredMode() {


### PR DESCRIPTION
## Summary
- default the site mode normalization to the basic experience when no preference is provided
- ensure ecommerce-only navigation entries like Pricing stay hidden unless ecommerce mode is explicitly enabled

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da0bc90c708333983c2c9dc882f42d