### PR TITLE
Set ecommerce as default site mode

### DIFF
--- a/assets/js/core/siteMode.js
+++ b/assets/js/core/siteMode.js
@@ -23,7 +23,7 @@ function normalizeMode(value) {
   const mode = String(value || "").toLowerCase();
   if (mode === SITE_MODES.ECOMMERCE) return SITE_MODES.ECOMMERCE;
   if (mode === SITE_MODES.BASIC) return SITE_MODES.BASIC;
-  return SITE_MODES.BASIC;
+  return SITE_MODES.ECOMMERCE;
 }
 
 function readStoredMode() {
@@ -37,6 +37,8 @@ function readStoredMode() {
     const envDefault = window.ENV?.site?.defaultMode;
     if (envDefault) {
       stored = envDefault;
+    } else {
+      stored = SITE_MODES.ECOMMERCE;
     }
   }
   return normalizeMode(stored);


### PR DESCRIPTION
## Summary
- default the runtime site mode to e-commerce when no stored or configured mode exists
- ensure storefront features like account creation stay available on fresh loads without custom configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da0f439ed08333a0f5953b4c7d54d1